### PR TITLE
Fix bitmap support

### DIFF
--- a/qpsdplugin.cpp
+++ b/qpsdplugin.cpp
@@ -188,12 +188,14 @@ bool qpsdHandler::read(QImage *image)
     {
     case 0: /*BITMAP*/
         {
-            //FIXME: image loads to "result" properly but becomes different when
-            //it passes the operator =
-            QImage result((uchar*)decompressed.data(),width, height, QImage::Format_Mono);
-            //output produced is inverted - black becomes white, white becomes black
-            result.invertPixels();
-            *image = result;
+            QString head = QString("P4\n%1 %2\n").arg(width).arg(height);
+            QByteArray buffer(head.toAscii());
+            buffer.append(decompressed);
+            QImage result = QImage::fromData(buffer);
+            if(result.isNull())
+                return false;
+            else
+                *image = result;
         }
 
         break;


### PR DESCRIPTION
I think the error in your code is about the image data, see QImage constructor:
QImage::QImage ( uchar \* data, int width, int height, Format format )
Constructs an image with the given width, height and format, that uses an existing memory buffer, data. The width and height must be specified in pixels, data must be 32-bit aligned, and each scanline of data in the image must also be 32-bit aligned.
The buffer must remain valid throughout the life of the QImage. The image does not delete the buffer at destruction.
