### PR TITLE
Fix bug with QImageIOPlugin::Capabilities()

### DIFF
--- a/qpsdplugin.cpp
+++ b/qpsdplugin.cpp
@@ -43,9 +43,11 @@ QImageIOPlugin::Capabilities QPsdPlugin::capabilities(
 {
     if (format == "psd" || format == "psb")
         return Capabilities(CanRead);//TODO: add CanWrite support
-    if (!(format.isEmpty() && device->isOpen()))
-        return 0;
-    return false;
+
+    Capabilities cap;
+    if (device->isReadable() && QPsdHandler::canRead(device))
+        cap |= CanRead;
+    return cap;
 }
 
 QImageIOHandler *QPsdPlugin::create(


### PR DESCRIPTION
I had fetched the lastest sources, compiled it and found it doesn't work. This is caused by QImageIOPlugin::Capabilities(), since it couldn't determine whether the format supportting. Then I fix it.
