### PR TITLE
Fix QImage format on Qt 5.10+

### DIFF
--- a/qpsdhandler_p.cpp
+++ b/qpsdhandler_p.cpp
@@ -490,7 +490,7 @@ QImage QPsdHandler::processRGB8WithAlpha(QByteArray& imageData, quint32 width, q
 #ifdef QT_DEBUG
     qDebug() << "8-bit RGB with Alpha";
 #endif
-    QImage result(width, height, QImage::Format_RGB32);
+	QImage result(width, height, QImage::Format_ARGB32);
     quint8 *red = (quint8*)imageData.constData();
     quint8 *green = red + totalBytesPerChannel;
     quint8 *blue = green + totalBytesPerChannel;


### PR DESCRIPTION
On Qt 5.10 .psd files with 8-bit RGB with Alpha reads as QImage QImage::Format_RGB32, i.e. without transparency. I don't know why it works on previous Qt versions