### PR TITLE
fixes crash for psb files > 2GB

### DIFF
--- a/qpsdhandler.cpp
+++ b/qpsdhandler.cpp
@@ -105,8 +105,8 @@ bool QPsdHandler::read(QImage *image)
 
     input >> compression;
 
-    quint64 totalBytesPerChannel = width * height * depth / 8;
-    quint64 size = channels * totalBytesPerChannel;
+    quint64 totalBytesPerChannel = (quint64)width * height * depth / 8;
+    quint64 size = (quint64)channels * totalBytesPerChannel;
     QByteArray imageData;
 
     switch (compression) {


### PR DESCRIPTION
- totalBytesPerChannel has an overflow if width * height * depth is > INT_MAX in line 108
- the cast avoids this overflow and `if ((quint64)imageData.size() != size)` in line 132 becomes true
- here is a test image: https://www.spacetelescope.org/static/archives/images/original/heic1502a.psb